### PR TITLE
Fix cover platform state constant imports for Home Assistant 2025.11

### DIFF
--- a/custom_components/inels_rpc/cover.py
+++ b/custom_components/inels_rpc/cover.py
@@ -4,12 +4,13 @@ import logging
 from pyinels.device.pyShutter import pyShutter
 from pyinels.pyTimer import TimerError
 
-from homeassistant.components.cover import (
-    CoverEntity,
+from homeassistant.components.cover import CoverEntity
+
+from homeassistant.const import (
     STATE_CLOSED,
     STATE_OPEN,
     STATE_CLOSING,
-    STATE_OPENING
+    STATE_OPENING,
 )
 
 from custom_components.inels_rpc.const import (


### PR DESCRIPTION
This PR updates the iNELS RPC cover platform to use the correct state constant imports required by newer versions of Home Assistant.

In Home Assistant 2025.11, state constants such as STATE_OPEN, STATE_CLOSED, STATE_OPENING and STATE_CLOSING are no longer exported from `homeassistant.components.cover`. 
They must now be imported from `homeassistant.const`.

The previous import caused the integration to fail during setup with:

`ImportError: cannot import name 'STATE_CLOSED' from 'homeassistant.components.cover'`


#### ✅ Changes
- Replace state constant imports from `homeassistant.components.cover` to `homeassistant.const`
- No functional behavior changes

#### 🧪 Tested
- Integration starts correctly

#### 🔗 Related
- https://github.com/home-assistant/core/pull/154037



Fixes #27 

Please take a look @jhoralek 


